### PR TITLE
Introduce rollout module for PPO

### DIFF
--- a/agilerl/rollouts/__init__.py
+++ b/agilerl/rollouts/__init__.py
@@ -1,0 +1,3 @@
+from .on_policy import collect_rollouts, collect_rollouts_recurrent
+
+__all__ = ["collect_rollouts", "collect_rollouts_recurrent"]

--- a/agilerl/rollouts/on_policy.py
+++ b/agilerl/rollouts/on_policy.py
@@ -1,0 +1,127 @@
+"""Functions for collecting rollouts for on-policy algorithms."""
+
+from typing import Optional
+
+import numpy as np
+import torch
+
+from agilerl.typing import GymEnvType
+from agilerl.algorithms.core.base import RLAlgorithm
+
+
+def _collect_rollouts(
+    agent: RLAlgorithm,
+    env: GymEnvType,
+    n_steps: Optional[int] = None,
+    *,
+    recurrent: bool,
+) -> None:
+    if not getattr(agent, "use_rollout_buffer", False):
+        raise RuntimeError(
+            "collect_rollouts can only be used when use_rollout_buffer=True"
+        )
+
+    n_steps = n_steps or agent.learn_step
+    agent.rollout_buffer.reset()
+
+    obs, info = env.reset()
+
+    agent.hidden_state = (
+        agent.get_initial_hidden_state(agent.num_envs) if recurrent else None
+    )
+    current_hidden_state_for_actor = agent.hidden_state
+
+    for _ in range(n_steps):
+        current_hidden_state_for_buffer = current_hidden_state_for_actor
+
+        if recurrent:
+            action, log_prob, _, value, next_hidden_for_actor = agent.get_action(
+                obs,
+                action_mask=info.get("action_mask", None),
+                hidden_state=current_hidden_state_for_actor,
+            )
+            agent.hidden_state = next_hidden_for_actor
+        else:
+            action, log_prob, _, value = agent.get_action(
+                obs, action_mask=info.get("action_mask", None)
+            )
+
+        next_obs, reward, done, truncated, next_info = env.step(action)
+
+        if isinstance(done, (list, np.ndarray)):
+            is_terminal = (
+                np.logical_or(done, truncated)
+                if isinstance(truncated, (list, np.ndarray))
+                else done
+            )
+        else:
+            is_terminal = done or truncated
+
+        reward_np = np.atleast_1d(reward)
+        is_terminal_np = np.atleast_1d(is_terminal)
+        value_np = np.atleast_1d(value)
+        log_prob_np = np.atleast_1d(log_prob)
+
+        agent.rollout_buffer.add(
+            obs=obs,
+            action=action,
+            reward=reward_np,
+            done=is_terminal_np,
+            value=value_np,
+            log_prob=log_prob_np,
+            next_obs=next_obs,
+            hidden_state=current_hidden_state_for_buffer,
+        )
+
+        if recurrent and np.any(is_terminal_np):
+            finished_mask = is_terminal_np.astype(bool)
+            initial_hidden_states_for_reset = agent.get_initial_hidden_state(
+                agent.num_envs
+            )
+            if isinstance(agent.hidden_state, dict):
+                for key in agent.hidden_state:
+                    reset_states_for_key = initial_hidden_states_for_reset[key][
+                        :, finished_mask, :
+                    ]
+                    if reset_states_for_key.shape[1] > 0:
+                        agent.hidden_state[key][
+                            :, finished_mask, :
+                        ] = reset_states_for_key
+
+        if recurrent:
+            current_hidden_state_for_actor = agent.hidden_state
+
+        obs = next_obs
+        info = next_info
+
+    with torch.no_grad():
+        if recurrent:
+            _, _, _, last_value, _ = agent._get_action_and_values(
+                agent.preprocess_observation(obs),
+                hidden_state=agent.hidden_state,
+            )
+        else:
+            _, _, _, last_value, _ = agent._get_action_and_values(
+                agent.preprocess_observation(obs)
+            )
+
+        last_value = last_value.cpu().numpy()
+        last_done = np.atleast_1d(done)
+
+    agent.rollout_buffer.compute_returns_and_advantages(
+        last_value=last_value, last_done=last_done
+    )
+
+
+def collect_rollouts(
+    agent: RLAlgorithm, env: GymEnvType, n_steps: Optional[int] = None
+) -> None:
+    """Collect rollouts for non-recurrent on-policy algorithms."""
+    return _collect_rollouts(agent, env, n_steps, recurrent=False)
+
+
+def collect_rollouts_recurrent(
+    agent: RLAlgorithm, env: GymEnvType, n_steps: Optional[int] = None
+) -> None:
+    """Collect rollouts for recurrent on-policy algorithms."""
+    return _collect_rollouts(agent, env, n_steps, recurrent=True)

--- a/agilerl/training/train_on_policy.py
+++ b/agilerl/training/train_on_policy.py
@@ -1,7 +1,7 @@
 import time
 import warnings
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import gymnasium as gym
 import numpy as np
@@ -49,6 +49,9 @@ def train_on_policy(
     verbose: bool = True,
     accelerator: Optional[Accelerator] = None,
     wandb_api_key: Optional[str] = None,
+    collect_rollouts_fn: Optional[
+        Callable[[OnPolicyAlgorithms, gym.Env, int], None]
+    ] = None,
 ) -> Tuple[PopulationType, List[List[float]]]:
     """The general on-policy RL training function. Returns trained population of agents
     and their fitnesses.
@@ -102,6 +105,10 @@ def train_on_policy(
     :type accelerator: accelerate.Accelerator(), optional
     :param wandb_api_key: API key for Weights & Biases, defaults to None
     :type wandb_api_key: str, optional
+    :param collect_rollouts_fn: Optional function used to collect rollouts. If
+        ``None`` and agents use a rollout buffer, a default function will be
+        selected based on whether the agent is recurrent.
+    :type collect_rollouts_fn: Callable or None, optional
 
     :return: Trained population of agents and their fitnesses
     :rtype: list[RLAlgorithm], list[list[float]]
@@ -204,95 +211,136 @@ def train_on_policy(
         for agent_idx, agent in enumerate(pop):  # Loop through population
             agent.set_training_mode(True)
 
-            state, info = env.reset()  # Reset environment at start of episode
             scores = np.zeros(num_envs)
             completed_episode_scores = []
             steps = 0
             start_time = time.time()
-            for _ in range(-(evo_steps // -agent.learn_step)):
-                states = []
-                actions = []
-                log_probs = []
-                rewards = []
-                dones = []
-                values = []
 
-                done = np.zeros(num_envs)
-                for idx_step in range(-(agent.learn_step // -num_envs)):
+            active_collect = collect_rollouts_fn
+            if active_collect is None and getattr(agent, "use_rollout_buffer", False):
+                if getattr(agent, "recurrent", False):
+                    from agilerl.rollouts import (
+                        collect_rollouts_recurrent as active_collect,
+                    )
+                else:
+                    from agilerl.rollouts import collect_rollouts as active_collect
 
-                    if swap_channels:
-                        state = obs_channels_to_first(state)
+            if (
+                getattr(agent, "use_rollout_buffer", False)
+                and active_collect is not None
+            ):
+                for _ in range(-(evo_steps // -agent.learn_step)):
+                    active_collect(agent, env, n_steps=agent.learn_step)
 
-                    # Get next action from agent
-                    action_mask = info.get("action_mask", None)
-                    action, log_prob, entropy, value = agent.get_action(
-                        state, action_mask=action_mask
+                    buffer_size = agent.rollout_buffer.pos
+                    rewards_np = (
+                        agent.rollout_buffer.buffer["rewards"][:buffer_size]
+                        .cpu()
+                        .numpy()
+                    )
+                    dones_np = (
+                        agent.rollout_buffer.buffer["dones"][:buffer_size].cpu().numpy()
                     )
 
-                    if not is_vectorised:
-                        action = action[0]
-                        log_prob = log_prob[0]
-                        value = value[0]
-                        entropy = entropy[0] if hasattr(entropy, "__len__") else entropy
+                    for r_step, d_step in zip(rewards_np, dones_np):
+                        scores += np.array(r_step)
+                        finished = np.array(d_step, dtype=bool)
+                        for idx, fin in enumerate(finished):
+                            if fin:
+                                completed_episode_scores.append(scores[idx])
+                                agent.scores.append(scores[idx])
+                                scores[idx] = 0
 
-                    # Store entropy value
-                    pop_entropy[agent_idx].append(entropy)
+                    steps += buffer_size * num_envs
+                    total_steps += buffer_size * num_envs
 
-                    # Clip to action space
-                    if isinstance(agent.action_space, spaces.Box):
-                        if agent.actor.squash_output:
-                            clipped_action = agent.actor.scale_action(action)
-                        else:
-                            clipped_action = np.clip(
-                                action, agent.action_space.low, agent.action_space.high
+                    loss = agent.learn()
+                    pop_loss[agent_idx].append(loss)
+
+            else:
+                state, info = env.reset()
+                for _ in range(-(evo_steps // -agent.learn_step)):
+                    states = []
+                    actions = []
+                    log_probs = []
+                    rewards = []
+                    dones = []
+                    values = []
+
+                    done = np.zeros(num_envs)
+                    for idx_step in range(-(agent.learn_step // -num_envs)):
+                        if swap_channels:
+                            state = obs_channels_to_first(state)
+
+                        action_mask = info.get("action_mask", None)
+                        action, log_prob, entropy, value = agent.get_action(
+                            state, action_mask=action_mask
+                        )
+
+                        if not is_vectorised:
+                            action = action[0]
+                            log_prob = log_prob[0]
+                            value = value[0]
+                            entropy = (
+                                entropy[0] if hasattr(entropy, "__len__") else entropy
                             )
-                    else:
-                        clipped_action = action
 
-                    # Act in environment
-                    next_state, reward, term, trunc, info = env.step(clipped_action)
-                    next_done = np.logical_or(term, trunc).astype(np.int8)
+                        pop_entropy[agent_idx].append(entropy)
 
-                    total_steps += num_envs
-                    steps += num_envs
+                        if isinstance(agent.action_space, spaces.Box):
+                            if agent.actor.squash_output:
+                                clipped_action = agent.actor.scale_action(action)
+                            else:
+                                clipped_action = np.clip(
+                                    action,
+                                    agent.action_space.low,
+                                    agent.action_space.high,
+                                )
+                        else:
+                            clipped_action = action
 
-                    states.append(state)
-                    actions.append(action)
-                    log_probs.append(log_prob)
-                    rewards.append(reward)
-                    dones.append(done)
-                    values.append(value)
+                        next_state, reward, term, trunc, info = env.step(clipped_action)
+                        next_done = np.logical_or(term, trunc).astype(np.int8)
 
-                    state = next_state
-                    done = next_done
-                    scores += np.array(reward)
+                        total_steps += num_envs
+                        steps += num_envs
 
-                    if not is_vectorised:
-                        term = [term]
-                        trunc = [trunc]
+                        states.append(state)
+                        actions.append(action)
+                        log_probs.append(log_prob)
+                        rewards.append(reward)
+                        dones.append(done)
+                        values.append(value)
 
-                    for idx, (d, t) in enumerate(zip(term, trunc)):
-                        if d or t:
-                            completed_episode_scores.append(scores[idx])
-                            agent.scores.append(scores[idx])
-                            scores[idx] = 0
+                        state = next_state
+                        done = next_done
+                        scores += np.array(reward)
 
-                if swap_channels:
-                    next_state = obs_channels_to_first(next_state)
+                        if not is_vectorised:
+                            term = [term]
+                            trunc = [trunc]
 
-                experiences = (
-                    states,
-                    actions,
-                    log_probs,
-                    rewards,
-                    dones,
-                    values,
-                    next_state,
-                    next_done,
-                )
-                # Learn according to agent's RL algorithm
-                loss = agent.learn(experiences)
-                pop_loss[agent_idx].append(loss)
+                        for idx, (d, t) in enumerate(zip(term, trunc)):
+                            if d or t:
+                                completed_episode_scores.append(scores[idx])
+                                agent.scores.append(scores[idx])
+                                scores[idx] = 0
+
+                    if swap_channels:
+                        next_state = obs_channels_to_first(next_state)
+
+                    experiences = (
+                        states,
+                        actions,
+                        log_probs,
+                        rewards,
+                        dones,
+                        values,
+                        next_state,
+                        next_done,
+                    )
+                    loss = agent.learn(experiences)
+                    pop_loss[agent_idx].append(loss)
 
             agent.steps[-1] += steps
             fps = steps / (time.time() - start_time)

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -44,7 +44,9 @@ from agilerl.typing import (
 PreTrainedModelType = Union[PeftModel, PreTrainedModel]
 
 
-def share_encoder_parameters(policy: EvolvableNetwork, *others: EvolvableNetwork) -> None:
+def share_encoder_parameters(
+    policy: EvolvableNetwork, *others: EvolvableNetwork
+) -> None:
     """Shares the encoder parameters between the policy and any number of other networks.
 
     :param policy: The policy network whose encoder parameters will be used.
@@ -52,10 +54,8 @@ def share_encoder_parameters(policy: EvolvableNetwork, *others: EvolvableNetwork
     :param others: The other networks whose encoder parameters will be pinned to the policy.
     :type others: EvolvableNetwork
     """
-    assert isinstance(policy, EvolvableNetwork), "Policy must be an EvolvableNetwork"
-    assert all(
-        isinstance(other, EvolvableNetwork) for other in others
-    ), "All others must be EvolvableNetwork"
+    if not (hasattr(policy, "encoder") and all(hasattr(o, "encoder") for o in others)):
+        raise TypeError("Networks must have an 'encoder' attribute to share parameters")
 
     # detaching encoder parameters from computation graph reduces
     # memory overhead and speeds up training

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -44,9 +44,7 @@ from agilerl.typing import (
 PreTrainedModelType = Union[PeftModel, PreTrainedModel]
 
 
-def share_encoder_parameters(
-    policy: EvolvableNetwork, *others: EvolvableNetwork
-) -> None:
+def share_encoder_parameters(policy: EvolvableNetwork, *others: EvolvableNetwork) -> None:
     """Shares the encoder parameters between the policy and any number of other networks.
 
     :param policy: The policy network whose encoder parameters will be used.
@@ -54,8 +52,10 @@ def share_encoder_parameters(
     :param others: The other networks whose encoder parameters will be pinned to the policy.
     :type others: EvolvableNetwork
     """
-    if not (hasattr(policy, "encoder") and all(hasattr(o, "encoder") for o in others)):
-        raise TypeError("Networks must have an 'encoder' attribute to share parameters")
+    assert isinstance(policy, EvolvableNetwork), "Policy must be an EvolvableNetwork"
+    assert all(
+        isinstance(other, EvolvableNetwork) for other in others
+    ), "All others must be EvolvableNetwork"
 
     # detaching encoder parameters from computation graph reduces
     # memory overhead and speeds up training

--- a/agilerl/utils/utils.py
+++ b/agilerl/utils/utils.py
@@ -23,8 +23,6 @@ from agilerl.algorithms import (
     MADDPG,
     MATD3,
     PPO,
-    CPPO,
-    ICM_PPO,
     TD3,
     NeuralTS,
     NeuralUCB,

--- a/docs/api/rollouts/index.rst
+++ b/docs/api/rollouts/index.rst
@@ -1,7 +1,9 @@
 Rollouts
 ========
 
-Functions for collecting rollouts between an environment and an agent.
+Utilities for gathering trajectories of experience from an environment. These
+helpers can be used directly or passed to :func:`agilerl.training.train_on_policy.train_on_policy`
+to customise how agents interact with an environment.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/api/rollouts/index.rst
+++ b/docs/api/rollouts/index.rst
@@ -1,0 +1,9 @@
+Rollouts
+========
+
+Functions for collecting rollouts between an environment and an agent.
+
+.. toctree::
+   :maxdepth: 1
+
+   on_policy

--- a/docs/api/rollouts/on_policy.rst
+++ b/docs/api/rollouts/on_policy.rst
@@ -1,0 +1,6 @@
+On-Policy Rollout Functions
+===========================
+
+.. autofunction:: agilerl.rollouts.collect_rollouts
+
+.. autofunction:: agilerl.rollouts.collect_rollouts_recurrent

--- a/docs/api/rollouts/on_policy.rst
+++ b/docs/api/rollouts/on_policy.rst
@@ -1,6 +1,40 @@
 On-Policy Rollout Functions
 ===========================
 
+These helpers gather transitions from an environment using an on-policy agent.
+They fill the agent's rollout buffer so that calling ``agent.learn()`` will
+update the policy from the collected data.
+
 .. autofunction:: agilerl.rollouts.collect_rollouts
 
 .. autofunction:: agilerl.rollouts.collect_rollouts_recurrent
+
+Example
+-------
+
+Using a non-recurrent PPO agent::
+
+   import gymnasium as gym
+   from agilerl.algorithms import PPO
+   from agilerl.rollouts import collect_rollouts
+
+   env = gym.make("CartPole-v1")
+   agent = PPO(env.observation_space, env.action_space, use_rollout_buffer=True)
+
+   collect_rollouts(agent, env, n_steps=agent.learn_step)
+   agent.learn()
+
+For recurrent policies, use ``collect_rollouts_recurrent``::
+
+   num_envs = 4
+   env = gym.vector.SyncVectorEnv([lambda: gym.make("CartPole-v1")] * num_envs)
+   agent = PPO(
+       env.single_observation_space,
+       env.single_action_space,
+       use_rollout_buffer=True,
+       recurrent=True,
+       num_envs=num_envs,
+   )
+
+   collect_rollouts_recurrent(agent, env, n_steps=5)
+   agent.learn()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,6 +106,7 @@ Contents
    api/modules/index
    api/networks/index
    api/train
+   api/rollouts/index
    api/utils/index
    api/vector/index
    api/wrappers/index


### PR DESCRIPTION
## Summary
- extract PPO rollout collection to new `agilerl.rollouts` module
- support external rollout functions in `train_on_policy`
- document rollout helpers
- update tests for new API
- relax type checks when sharing encoder parameters

## Testing
- `pytest tests/test_algorithms/test_ppo.py::test_ppo_collect_rollouts -q`
- `pytest tests/test_algorithms/test_ppo.py::test_ppo_with_hidden_states_multiple_envs_collect_rollouts -q`
- `pytest tests/test_algorithms/test_ppo.py::test_ppo_wrap_at_capacity -q`
- `pytest tests/test_train/test_train.py::test_train_on_policy_agent_calls_made -q`


------
https://chatgpt.com/codex/tasks/task_e_6853ed0f639c83309dcf23d8fa595fdb